### PR TITLE
Darkshore Warfront (Alliance) flights

### DIFF
--- a/DarkshoreWarfront.lua
+++ b/DarkshoreWarfront.lua
@@ -1,0 +1,38 @@
+local addonName, ns = ...
+local L = ns.L
+
+local HBDP = LibStub('HereBeDragons-Pins-2.0')
+
+local DARKSHORE = 1203
+local destinations = {
+	[L['Send me to Bashal\'Aran.']]        = {x = 0.507, y = 0.549},
+	[L['Send me to Gloomtide Strand.']]    = {x = 0.467, y = 0.477},
+	[L['Send me to Cinderfall Grove.']]    = {x = 0.563, y = 0.441},
+}
+
+hooksecurefunc(ns.Handler, 'GOSSIP_SHOW', function(self)
+	if(IsShiftKeyDown()) then
+		 -- temporary disable
+		return
+	end
+
+	local npcID = self:GetNPCID()
+	if (npcID == 145743) then
+		self:Enable(DARKSHORE)
+
+		for index = 1, GetNumGossipOptions() do
+			local text = select((index * 2) - 1, GetGossipOptions())
+			local loc = destinations[text]
+			if(loc) then
+				local Marker = self:GetMarker()
+				Marker:SetID(index)
+				Marker:SetNormalAtlas('Taxi_Frame_Gray')
+				Marker:SetHighlightAtlas('Taxi_Frame_Yellow')
+				Marker:SetSize(24)
+				Marker:SetName(text)
+
+				HBDP:AddWorldMapIconMap(self, Marker, DARKSHORE, loc.x, loc.y)
+			end
+		end
+	end
+end)

--- a/InteractiveWormholes.toc
+++ b/InteractiveWormholes.toc
@@ -30,3 +30,4 @@ Vethir.lua
 MoleMachine.lua
 Footholds.lua
 UnderbellyPortals.lua
+DarkshoreWarfront.lua

--- a/locale/deDE.lua
+++ b/locale/deDE.lua
@@ -47,3 +47,7 @@ L['Cry More Thunder!'] = 'Noch mehr Donner des Schmerzes'
 -- L['Alchemists\' Lair'] = 'Versteck der Alchemisten' -- UNCONFIRMED TRANSLATION
 -- L['Abandoned Shack'] = 'Verlassene Hütte' -- UNCONFIRMED TRANSLATION
 -- L['Rear Entrance'] = 'Hintereingang' -- UNCONFIRMED TRANSLATION
+
+-- L['Send me to Bashal\'Aran.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Gloomtide Strand.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Cinderfall Grove.'] = '' -- MISSING TRANSLATION

--- a/locale/esES.lua
+++ b/locale/esES.lua
@@ -47,3 +47,7 @@ L['Cry More Thunder!'] = '¡Truenos y truenos!'
 -- L['Alchemists\' Lair'] = 'Guarida de los alquimistas' -- UNCONFIRMED TRANSLATION
 -- L['Abandoned Shack'] = 'Cabaña abandonada' -- UNCONFIRMED TRANSLATION
 -- L['Rear Entrance'] = 'Entrada trasera' -- UNCONFIRMED TRANSLATION
+
+-- L['Send me to Bashal\'Aran.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Gloomtide Strand.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Cinderfall Grove.'] = '' -- MISSING TRANSLATION

--- a/locale/esMX.lua
+++ b/locale/esMX.lua
@@ -46,3 +46,7 @@ L['Broken Shore'] = 'Costa Quebrada'
 -- L['Alchemists\' Lair'] = '' -- MISSING TRANSLATION
 -- L['Abandoned Shack'] = '' -- MISSING TRANSLATION
 -- L['Rear Entrance'] = '' -- MISSING TRANSLATION
+
+-- L['Send me to Bashal\'Aran.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Gloomtide Strand.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Cinderfall Grove.'] = '' -- MISSING TRANSLATION

--- a/locale/frFR.lua
+++ b/locale/frFR.lua
@@ -47,3 +47,7 @@ L['Cry More Thunder!'] = 'Tonnerre ailé'
 -- L['Alchemists\' Lair'] = 'antre des alchimistes' -- UNCONFIRMED TRANSLATION
 -- L['Abandoned Shack'] = 'cabane abandonnée' -- UNCONFIRMED TRANSLATION
 -- L['Rear Entrance'] = 'porte de derrière' -- UNCONFIRMED TRANSLATION
+
+-- L['Send me to Bashal\'Aran.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Gloomtide Strand.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Cinderfall Grove.'] = '' -- MISSING TRANSLATION

--- a/locale/itIT.lua
+++ b/locale/itIT.lua
@@ -47,3 +47,7 @@ L['Cry More Thunder!'] = 'Il ruggito più potente del tuono!'
 -- L['Alchemists\' Lair'] = 'Antro degli Alchimisti' -- UNCONFIRMED TRANSLATION
 -- L['Abandoned Shack'] = 'Capanno Abbandonato' -- UNCONFIRMED TRANSLATION
 -- L['Rear Entrance'] = 'Entrata Posteriore' -- UNCONFIRMED TRANSLATION
+
+-- L['Send me to Bashal\'Aran.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Gloomtide Strand.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Cinderfall Grove.'] = '' -- MISSING TRANSLATION

--- a/locale/koKR.lua
+++ b/locale/koKR.lua
@@ -47,3 +47,7 @@ L['Cry More Thunder!'] = '더 퍼부어라!'
 -- L['Alchemists\' Lair'] = '연금술사의 방' -- UNCONFIRMED TRANSLATION
 -- L['Abandoned Shack'] = '버려진 집' -- UNCONFIRMED TRANSLATION
 -- L['Rear Entrance'] = '후문' -- UNCONFIRMED TRANSLATION
+
+-- L['Send me to Bashal\'Aran.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Gloomtide Strand.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Cinderfall Grove.'] = '' -- MISSING TRANSLATION

--- a/locale/ptBR.lua
+++ b/locale/ptBR.lua
@@ -47,3 +47,7 @@ L['Cry More Thunder!'] = 'Mais trovoadas!'
 -- L['Alchemists\' Lair'] = 'Covil do Alquimista' -- UNCONFIRMED TRANSLATION
 -- L['Abandoned Shack'] = 'Cabana abandonada' -- UNCONFIRMED TRANSLATION
 -- L['Rear Entrance'] = 'Entrada dos Fundos' -- UNCONFIRMED TRANSLATION
+
+-- L['Send me to Bashal\'Aran.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Gloomtide Strand.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Cinderfall Grove.'] = '' -- MISSING TRANSLATION

--- a/locale/ruRU.lua
+++ b/locale/ruRU.lua
@@ -47,3 +47,7 @@ L['Cry More Thunder!'] = 'И снова гром и молния!'
 -- L['Alchemists\' Lair'] = 'логово алхимика' -- UNCONFIRMED TRANSLATION
 -- L['Abandoned Shack'] = 'заброшенная лачуга' -- UNCONFIRMED TRANSLATION
 -- L['Rear Entrance'] = 'черный ход' -- UNCONFIRMED TRANSLATION
+
+-- L['Send me to Bashal\'Aran.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Gloomtide Strand.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Cinderfall Grove.'] = '' -- MISSING TRANSLATION

--- a/locale/zhCN.lua
+++ b/locale/zhCN.lua
@@ -46,3 +46,7 @@ L['Broken Shore'] = '破碎海滩'
 -- L['Alchemists\' Lair'] = '炼金师之巢' -- UNCONFIRMED TRANSLATION
 -- L['Abandoned Shack'] = '废弃小屋' -- UNCONFIRMED TRANSLATION
 -- L['Rear Entrance'] = '后门' -- UNCONFIRMED TRANSLATION
+
+-- L['Send me to Bashal\'Aran.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Gloomtide Strand.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Cinderfall Grove.'] = '' -- MISSING TRANSLATION

--- a/locale/zhTW.lua
+++ b/locale/zhTW.lua
@@ -46,3 +46,7 @@ L['Broken Shore'] = '破碎海岸'
 -- L['Alchemists\' Lair'] = '' -- MISSING TRANSLATION
 -- L['Abandoned Shack'] = '' -- MISSING TRANSLATION
 -- L['Rear Entrance'] = '' -- MISSING TRANSLATION
+
+-- L['Send me to Bashal\'Aran.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Gloomtide Strand.'] = '' -- MISSING TRANSLATION
+-- L['Send me to Cinderfall Grove.'] = '' -- MISSING TRANSLATION


### PR DESCRIPTION
Adds support for the Alliance flights during the Darkshore Warfront (attack phase).

I'm sure there will be a Horde equivalent but I don't have a Horde character high enough to find out. 