### PR TITLE
New module - Skyhold flight NPC

### DIFF
--- a/locale/deDE.lua
+++ b/locale/deDE.lua
@@ -63,3 +63,11 @@ L['Broken Shore'] = 'Die Verheerte Küste'
 -- L['Gloomtide Strand'] = '' -- MISSING TRANSLATION
 -- L['Cinderfall Grove'] = '' -- MISSING TRANSLATION
 -- L['Lor\'danel Landing'] = '' -- MISSING TRANSLATION
+
+--- Legion Zones (for Skyhold module)
+-- L['Dalaran'] = '' -- MISSING TRANSLATION
+-- L['Stormheim'] = '' -- MISSING TRANSLATION
+-- L['Azsuna'] = '' -- MISSING TRANSLATION
+-- L['Val\'sharah'] = '' -- MISSING TRANSLATION
+-- L['Highmountain'] = '' -- MISSING TRANSLATION
+-- L['Suramar'] = '' -- MISSING TRANSLATION

--- a/locale/esES.lua
+++ b/locale/esES.lua
@@ -63,3 +63,11 @@ L['Broken Shore'] = 'Costa Abrupta'
 -- L['Gloomtide Strand'] = '' -- MISSING TRANSLATION
 -- L['Cinderfall Grove'] = '' -- MISSING TRANSLATION
 -- L['Lor\'danel Landing'] = '' -- MISSING TRANSLATION
+
+--- Legion Zones (for Skyhold module)
+-- L['Dalaran'] = '' -- MISSING TRANSLATION
+-- L['Stormheim'] = '' -- MISSING TRANSLATION
+-- L['Azsuna'] = '' -- MISSING TRANSLATION
+-- L['Val\'sharah'] = '' -- MISSING TRANSLATION
+-- L['Highmountain'] = '' -- MISSING TRANSLATION
+-- L['Suramar'] = '' -- MISSING TRANSLATION

--- a/locale/esMX.lua
+++ b/locale/esMX.lua
@@ -63,3 +63,11 @@ L['Broken Shore'] = 'Costa Quebrada'
 -- L['Gloomtide Strand'] = '' -- MISSING TRANSLATION
 -- L['Cinderfall Grove'] = '' -- MISSING TRANSLATION
 -- L['Lor\'danel Landing'] = '' -- MISSING TRANSLATION
+
+--- Legion Zones (for Skyhold module)
+-- L['Dalaran'] = '' -- MISSING TRANSLATION
+-- L['Stormheim'] = '' -- MISSING TRANSLATION
+-- L['Azsuna'] = '' -- MISSING TRANSLATION
+-- L['Val\'sharah'] = '' -- MISSING TRANSLATION
+-- L['Highmountain'] = '' -- MISSING TRANSLATION
+-- L['Suramar'] = '' -- MISSING TRANSLATION

--- a/locale/frFR.lua
+++ b/locale/frFR.lua
@@ -63,3 +63,11 @@ L['Broken Shore'] = 'Rivage Brisé'
 -- L['Gloomtide Strand'] = '' -- MISSING TRANSLATION
 -- L['Cinderfall Grove'] = '' -- MISSING TRANSLATION
 -- L['Lor\'danel Landing'] = '' -- MISSING TRANSLATION
+
+--- Legion Zones (for Skyhold module)
+-- L['Dalaran'] = '' -- MISSING TRANSLATION
+-- L['Stormheim'] = '' -- MISSING TRANSLATION
+-- L['Azsuna'] = '' -- MISSING TRANSLATION
+-- L['Val\'sharah'] = '' -- MISSING TRANSLATION
+-- L['Highmountain'] = '' -- MISSING TRANSLATION
+-- L['Suramar'] = '' -- MISSING TRANSLATION

--- a/locale/itIT.lua
+++ b/locale/itIT.lua
@@ -63,3 +63,11 @@ L['Broken Shore'] = 'Riva Dispersa'
 -- L['Gloomtide Strand'] = '' -- MISSING TRANSLATION
 -- L['Cinderfall Grove'] = '' -- MISSING TRANSLATION
 -- L['Lor\'danel Landing'] = '' -- MISSING TRANSLATION
+
+--- Legion Zones (for Skyhold module)
+-- L['Dalaran'] = '' -- MISSING TRANSLATION
+-- L['Stormheim'] = '' -- MISSING TRANSLATION
+-- L['Azsuna'] = '' -- MISSING TRANSLATION
+-- L['Val\'sharah'] = '' -- MISSING TRANSLATION
+-- L['Highmountain'] = '' -- MISSING TRANSLATION
+-- L['Suramar'] = '' -- MISSING TRANSLATION

--- a/locale/koKR.lua
+++ b/locale/koKR.lua
@@ -63,3 +63,11 @@ L['Broken Shore'] = '부서진 해변'
 -- L['Gloomtide Strand'] = '' -- MISSING TRANSLATION
 -- L['Cinderfall Grove'] = '' -- MISSING TRANSLATION
 -- L['Lor\'danel Landing'] = '' -- MISSING TRANSLATION
+
+--- Legion Zones (for Skyhold module)
+-- L['Dalaran'] = '' -- MISSING TRANSLATION
+-- L['Stormheim'] = '' -- MISSING TRANSLATION
+-- L['Azsuna'] = '' -- MISSING TRANSLATION
+-- L['Val\'sharah'] = '' -- MISSING TRANSLATION
+-- L['Highmountain'] = '' -- MISSING TRANSLATION
+-- L['Suramar'] = '' -- MISSING TRANSLATION

--- a/locale/ptBR.lua
+++ b/locale/ptBR.lua
@@ -63,3 +63,11 @@ L['Broken Shore'] = 'Costa Partida'
 -- L['Gloomtide Strand'] = '' -- MISSING TRANSLATION
 -- L['Cinderfall Grove'] = '' -- MISSING TRANSLATION
 -- L['Lor\'danel Landing'] = '' -- MISSING TRANSLATION
+
+--- Legion Zones (for Skyhold module)
+-- L['Dalaran'] = '' -- MISSING TRANSLATION
+-- L['Stormheim'] = '' -- MISSING TRANSLATION
+-- L['Azsuna'] = '' -- MISSING TRANSLATION
+-- L['Val\'sharah'] = '' -- MISSING TRANSLATION
+-- L['Highmountain'] = '' -- MISSING TRANSLATION
+-- L['Suramar'] = '' -- MISSING TRANSLATION

--- a/locale/ruRU.lua
+++ b/locale/ruRU.lua
@@ -63,3 +63,11 @@ L['Broken Shore'] = 'Расколотый берег'
 -- L['Gloomtide Strand'] = '' -- MISSING TRANSLATION
 -- L['Cinderfall Grove'] = '' -- MISSING TRANSLATION
 -- L['Lor\'danel Landing'] = '' -- MISSING TRANSLATION
+
+--- Legion Zones (for Skyhold module)
+-- L['Dalaran'] = '' -- MISSING TRANSLATION
+-- L['Stormheim'] = '' -- MISSING TRANSLATION
+-- L['Azsuna'] = '' -- MISSING TRANSLATION
+-- L['Val\'sharah'] = '' -- MISSING TRANSLATION
+-- L['Highmountain'] = '' -- MISSING TRANSLATION
+-- L['Suramar'] = '' -- MISSING TRANSLATION

--- a/locale/zhCN.lua
+++ b/locale/zhCN.lua
@@ -63,3 +63,11 @@ L['Broken Shore'] = '破碎海滩'
 -- L['Gloomtide Strand'] = '' -- MISSING TRANSLATION
 -- L['Cinderfall Grove'] = '' -- MISSING TRANSLATION
 -- L['Lor\'danel Landing'] = '' -- MISSING TRANSLATION
+
+--- Legion Zones (for Skyhold module)
+-- L['Dalaran'] = '' -- MISSING TRANSLATION
+-- L['Stormheim'] = '' -- MISSING TRANSLATION
+-- L['Azsuna'] = '' -- MISSING TRANSLATION
+-- L['Val\'sharah'] = '' -- MISSING TRANSLATION
+-- L['Highmountain'] = '' -- MISSING TRANSLATION
+-- L['Suramar'] = '' -- MISSING TRANSLATION

--- a/locale/zhTW.lua
+++ b/locale/zhTW.lua
@@ -63,3 +63,11 @@ L['Broken Shore'] = '破碎海岸'
 -- L['Gloomtide Strand'] = '' -- MISSING TRANSLATION
 -- L['Cinderfall Grove'] = '' -- MISSING TRANSLATION
 -- L['Lor\'danel Landing'] = '' -- MISSING TRANSLATION
+
+--- Legion Zones (for Skyhold module)
+-- L['Dalaran'] = '' -- MISSING TRANSLATION
+-- L['Stormheim'] = '' -- MISSING TRANSLATION
+-- L['Azsuna'] = '' -- MISSING TRANSLATION
+-- L['Val\'sharah'] = '' -- MISSING TRANSLATION
+-- L['Highmountain'] = '' -- MISSING TRANSLATION
+-- L['Suramar'] = '' -- MISSING TRANSLATION

--- a/modules/Skyhold.lua
+++ b/modules/Skyhold.lua
@@ -1,0 +1,35 @@
+local addon = select(2, ...)
+local L = addon.L
+
+local BROKENISLES = 619
+local destinations = {
+	[L['Dalaran']] 			= {zone = 627, x = 0.7246, y = 0.4594},
+	[L['Stormheim']] 		= {zone = 634, x = 0.6034, y = 0.5106},
+	[L['Azsuna']] 			= {zone = 630, x = 0.4749, y = 0.2755},
+	[L['Val\'sharah']] 		= {zone = 641, x = 0.5462, y = 0.7313},
+	[L['Highmountain']] 	= {zone = 750, x = 0.3853, y = 0.4554},
+	[L['Suramar']] 			= {zone = 680, x = 0.3381, y = 0.4940},
+	[L['Broken Shore']] 	= {zone = 646, x = 0.4427, y = 0.6299},
+}
+
+addon:Add(function(self)
+	local npcID = self:GetNPCID()
+	if(npcID == 96679) then
+		self:SetMapID(BROKENISLES)
+
+		for index, line in next, self:GetLines() do
+			for name, loc in next, destinations do
+				if(line:match(name)) then
+					local Marker = self:NewMarker()
+					Marker:SetID(index)
+					Marker:SetTitle(name)
+					Marker:SetNormalAtlas('Taxi_Frame_Gray')
+					Marker:SetHighlightAtlas('Taxi_Frame_Yellow')
+					Marker:SetSize(24)
+
+					Marker:Pin(loc.zone, loc.x, loc.y, true)
+				end
+			end
+		end
+	end
+end)

--- a/modules/modules.xml
+++ b/modules/modules.xml
@@ -1,6 +1,7 @@
 <Ui>
 	<Script file='Footholds.lua'/>
 	<Script file='MoleMachine.lua'/>
+	<Script file='Skyhold.lua'/>
 	<Script file='UnderbellyPortals.lua'/>
 	<Script file='Vethir.lua'/>
 	<Script file='Warfronts.lua'/>


### PR DESCRIPTION
This is for the flight master (Stormflight Master) NPC in Skyhold (class hall for Warriors in Legion).

There's probably a better icon to use than the flight master boot but I don't know what to use for this at the moment.

"Broken Shore" is one of the destinations but it is already translated so I left it where it is.

Before:
![wowscrnshot_011519_193546](https://user-images.githubusercontent.com/1292866/51219035-fa334500-18fc-11e9-9a31-e2b7004639e3.jpg)

After:
![wowscrnshot_011519_193631](https://user-images.githubusercontent.com/1292866/51219052-0ae3bb00-18fd-11e9-86f3-8dccb7987868.jpg)
